### PR TITLE
Move proto file loading to a compile step instead of download.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import protobuf, { convertFieldsToCamelCase } from 'protobufjs'
+import p from './studioapi.proto.js';
 
 /**
  * The studio namespace.
@@ -18,7 +19,7 @@ var studio = (function() {
  */
 studio.protocol = (function(ProtoBuf) {
   var obj = {},
-        studioBuilder = ProtoBuf.loadProtoFile("./studioapi.proto");
+        studioBuilder = ProtoBuf.loadProto(p);
   obj.Hello = studioBuilder.build("Hello");
   obj.AuthRequest = studioBuilder.build("AuthRequest");
   obj.AuthRequestChallengeResponse = studioBuilder.build("AuthRequest.ChallengeResponse");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdp-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A simple Javascript interface for the CDP Studio development platform that allows Javascript applications to interact with",
   "main": "index.js",
   "scripts": {

--- a/studioapi.proto.js
+++ b/studioapi.proto.js
@@ -1,3 +1,4 @@
+const p = `
 // This file describes the StudioAPI wire protocol. It can be compiled with
 // the Google Protobuf protoc compiler into native C++, Java, Python etc.
 
@@ -232,4 +233,5 @@ message ValueRequest {
                                    // missing or zero means all samples must be provided
   extensions 100 to max;
 }
-
+`;
+export default p;


### PR DESCRIPTION
This resolves issues related to download path when cdpclient is used.